### PR TITLE
Generalise signature of Find

### DIFF
--- a/pkg/yamlpath/example_test.go
+++ b/pkg/yamlpath/example_test.go
@@ -48,7 +48,10 @@ spec:
 		log.Fatalf("cannot create path: %v", err)
 	}
 
-	q := p.Find(&n)
+	q, err := p.Find(&n)
+	if err != nil {
+		log.Fatalf("unexpected error: %v", err)
+	}
 
 	for _, i := range q {
 		i.Value = "example.com/user/" + i.Value

--- a/pkg/yamlpath/filter.go
+++ b/pkg/yamlpath/filter.go
@@ -7,6 +7,7 @@
 package yamlpath
 
 import (
+	"fmt"
 	"regexp"
 
 	"gopkg.in/yaml.v3"
@@ -136,7 +137,10 @@ func pathFilterScanner(n *filterNode) filterScanner {
 	}
 }
 
-func values(nodes []*yaml.Node) []string {
+func values(nodes []*yaml.Node, err error) []string {
+	if err != nil {
+		panic(fmt.Errorf("unexpected error: %v", err)) // should never happen
+	}
 	v := []string{}
 	for _, n := range nodes {
 		v = append(v, n.Value)

--- a/pkg/yamlpath/path.go
+++ b/pkg/yamlpath/path.go
@@ -20,8 +20,8 @@ type Path struct {
 }
 
 // Find applies the Path to a YAML node and returns the addresses of the subnodes which match the Path.
-func (p *Path) Find(node *yaml.Node) []*yaml.Node {
-	return p.find(node, node)
+func (p *Path) Find(node *yaml.Node) ([]*yaml.Node, error) {
+	return p.find(node, node), nil // currently, errors are not possible
 }
 
 func (p *Path) find(node, root *yaml.Node) []*yaml.Node {

--- a/pkg/yamlpath/path_test.go
+++ b/pkg/yamlpath/path_test.go
@@ -894,7 +894,8 @@ price: 12.99
 				return
 			}
 
-			actual := p.Find(&n)
+			actual, err := p.Find(&n)
+			require.NoError(t, err)
 
 			actualStrings := []string{}
 			for _, a := range actual {
@@ -964,7 +965,8 @@ a: b`,
 				return
 			}
 
-			actual := p.Find(&n)
+			actual, err := p.Find(&n)
+			require.NoError(t, err)
 
 			actualStrings := []string{}
 			for _, a := range actual {

--- a/web/main.go
+++ b/web/main.go
@@ -118,7 +118,10 @@ textarea, input {
 			return
 		}
 
-		results := path.Find(&n)
+		results, err := path.Find(&n)
+		if err != nil {
+			respondWithError(w, err)
+		}
 
 		out := []string{}
 		for _, a := range results {


### PR DESCRIPTION
Adopting the signature:
```
Find(root *yaml.Node) ([]*yaml.Node, error)
```

allows this library to be consumed more easily by YAML editors, such as [yamled](https://github.com/vmware-labs/yaml-jsonpointer/blob/3311f424a64e879e147c19be6fd8252f90c07b3e/yamled/doc.go), and the like.